### PR TITLE
Fix spot/test.json

### DIFF
--- a/testcases/spot/test.json
+++ b/testcases/spot/test.json
@@ -1,7 +1,7 @@
 {
   "frames": [
     {
-      "name": "",
+      "name": "TEST",
       "rms_error": 3.815e-06,
       "peak_error": 3.815e-06
     }
@@ -31,6 +31,6 @@
   "sha256sums": {
     "reference.icc": "ce0caee9506116ea94d7367d646f7fd6d0b7e82feb8d1f3de4edb3ba57bae07e",
     "original.icc": "ce0caee9506116ea94d7367d646f7fd6d0b7e82feb8d1f3de4edb3ba57bae07e",
-    "reference_image.npy": "82de72e756db992792b8e3eb5eac5194ef83e9ab4dc03e846492fbedde7b58da",
+    "reference_image.npy": "82de72e756db992792b8e3eb5eac5194ef83e9ab4dc03e846492fbedde7b58da"
   }
 }


### PR DESCRIPTION
The frame name is TEST and trailing commas are not supported

Note that spot should be added to main_level5.txt and main_level10.txt,
but cannot be done yet until the conformance decoder supports spot color
channels