### PR TITLE
increase allowed peak_error in a few test cases

### DIFF
--- a/testcases/animation_icos4d/test.json
+++ b/testcases/animation_icos4d/test.json
@@ -4,289 +4,289 @@
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     },
     {
       "duration": 0.05,
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.005
     }
   ],
   "intensity_target": 255.0,

--- a/testcases/bike/test.json
+++ b/testcases/bike/test.json
@@ -3,7 +3,7 @@
     {
       "name": "",
       "rms_error": 0.0001,
-      "peak_error": 0.004
+      "peak_error": 0.007
     }
   ],
   "intensity_target": 255.0,


### PR DESCRIPTION
the level 10 test on bike and animation_icos4d gives a larager peak
error on some CPU's (tested with same binary and compiler on AMD and
intel machine, and we get different results)

The bike test has an error of 0.0061, so using 0.007