### PR TITLE
Change lib dependency liblcms2.so -> liblcms2.so.2

### DIFF
--- a/scripts/lcms2.py
+++ b/scripts/lcms2.py
@@ -12,7 +12,7 @@ from numpy.ctypeslib import ndpointer
 import numpy
 import os
 
-lcms2_lib_path = os.getenv("LCMS2_LIB_PATH", "liblcms2.so")
+lcms2_lib_path = os.getenv("LCMS2_LIB_PATH", "liblcms2.so.2")
 lcms2_lib = ctypes.cdll.LoadLibrary(lcms2_lib_path)
 
 native_open_profile = lcms2_lib.cmsOpenProfileFromMem


### PR DESCRIPTION
liblcms2.so exists on some Linux distributions, but not others. The latter will always exist.