### PR TITLE
add more license info

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) the JPEG XL Project Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/testcases/README.md
+++ b/testcases/README.md
@@ -1,0 +1,37 @@
+# Test cases
+This folder contains test bitstreams for testing conformance of JPEG XL decoders.
+
+All test bitstreams and reference decoded images can be reproduced freely for testing purposes.
+
+The licenses of the source images or animations these bitstreams were based on are as follows:
+
+| test case  	| license/source |
+|---	|---	|
+| alpha_nonpremultiplied | CC0 |
+| alpha_premultiplied | CC0 |
+| alpha_triangle  | CC0 |
+| animation_icos4D  | [CC0](https://commons.wikimedia.org/wiki/File:24-cell-orig.gif) |
+| animation_newtons_cradle | [CC BY-SA 3.0](https://commons.wikimedia.org/wiki/File:Newtons_cradle_animation_book_2.gif) |
+| animation_spline | CC0 |
+| bench_oriented_BRG | CC0 |
+| bicycles | CC0 |
+| bike | ITU-T T.24 |
+| blendmodes | CC0 |
+| cafe | ITU-T T.24 |
+| cmyk_layers | CC0 |
+| delta_palette | CC0 |
+| grayscale | CC0 |
+| grayscale_jpeg | CC0 |
+| grayscale_public_university | CC BY 3.0, Arnold and Richter Cine Technik GmbH |
+| lossless_pfm | CC0 |
+| lz77_flower | CC0 |
+| noise | CC0 |
+| opsin_inverse | CC0 |
+| patches | CC0 |
+| patches_lossless | CC0 |
+| progressive | [Microsoft custom license](progressive/source) |
+| spot | CC0 |
+| sunset_logo | CC0 |
+| upsampling | [CC BY-SA 3.0](https://commons.wikimedia.org/wiki/File:PNG_transparency_demonstration_1.png) |
+
+

--- a/testcases/animation_icos4d/source
+++ b/testcases/animation_icos4d/source
@@ -1,3 +1,4 @@
 Link: https://web.archive.org/web/20111221090506mp_/http://s826.photobucket.com/albums/zz190/apng/?action=view&current=APNG-Icos4D.png
-Author: Unknown
-License: Unknown
+Link: https://commons.wikimedia.org/wiki/File:24-cell-orig.gif
+Author: Jason Hise
+License: CC0

--- a/testcases/bike/itu-t.24_ReadMe.txt
+++ b/testcases/bike/itu-t.24_ReadMe.txt
@@ -1,0 +1,105 @@
+--------------------------------------------------------------
+	    README FILE FOR THE T.24 DIGITIZED IMAGE SET
+--------------------------------------------------------------
+
+TITLE
+-----
+
+ ITU-T T.24 (06/1998) - Standardized digitized image set
+ (CD-04 edition)
+
+Test images have played an important role throughout the development of Group 3
+and Group 4 facsimile. This digitized test chart set has been prepared with the
+goal of providing a standard set of images to facsimile experimenters. The set
+includes images that have been used over the years plus new images that are
+applicable for gray scale and color. The standard set of images will provide a
+consistent baseline for further work; for example, results of compression
+algorithm experiments and image quality tests can be compared by a broad range
+of users, knowing that the input image data is identical
+
+This digitized test chart set is an integral part of ITU-T Rec. T.24 and is
+published with it. The two CD-ROMs include a set of digitized images with
+different resolutions. A detailed description is given in T.24 for each test
+chart.
+
+COPYRIGHT AND INTELLECTUAL PROPERTY
+-----------------------------------
+
+In order to preserve and protect its rights, the International Telecommunication
+Union (ITU) fully retains all titles and rights in this software and does not
+sell any rights related thereto; it grants, however, the right to use the
+software by means of a licence not implying in any way any sale, renting or
+otherwise gain financial profit from making available the original software or
+any copy thereof.
+
+By the present licence, ITU grants users of the software a non-exclusive right
+to freely reproduce the information contained therein, so that it may be used
+for intended purposes only. Use of the software constitutes the agreement by
+users of the terms and conditions of the present notice.
+
+The present notice must be included in any copy of the software or the
+information contained therein.
+
+ITU CONTACTS
+------------
+
+For distribution of update software, please contact:
+Sales Department
+ITU
+Place des Nations
+CH-1211 Geneve 20
+SUISSE
+email: sales@itu.int
+
+For reporting problems, please contact TSB helpdesk service at:
+TSB Helpdesk service
+ITU
+Place des Nations
+CH-1211 Geneve 20
+SUISSE
+fax: +41 22 730 5853
+email: tsbedh@itu.int
+
+USAGE INSTRUCTIONS:
+-------------------
+
+The images can be viewed with any available viewer complying with the TIFF
+specification.
+
+Among others, there are the following shareware: VuePrint from Hamrick Software
+at http://www.hamrick.com and Paint Shop Pro at http://www.jasc.com.
+
+Located in the root directory of the first CD-ROM, you'll find the TIFF
+Specification Revision 6.0 in pdf format:
+
+   Tiff6.pdf           TIFF Specification Revision 6.0
+
+The following copyright statement is included in the TIFF Specification Revision 6.0:
+
+(c) 1986-1988, 1992 Aldus Corporation. Permission to copy without fee all
+or part of this material is granted provided that the copies are not made or
+distributed for direct commercial advantage and the Aldus copyright notice appears.
+If the majority of the document is copied or redistributed, it must be distributed
+verbatim, without repagination or reformatting. To copy otherwise requires specific
+permission from the Aldus Corporation.
+
+CD-ROM CONTENTS:
+----------------
+
+The first CD-ROM contains the charts which were already included in 1994 version.
+The second CD-ROM contains the supplementary test charts introduced in 1998 edition.
+
+The files are organized as follows:
+
+CD-ROM 1:
+  - IMAGE1      : A directory containing 1st CD-ROM test charts
+ imgspec1.rtf   : Image specification for CD-ROM1 in rtf format
+ imgspec1.txt   : Image specification for CD-ROM1 in txt format
+ readme.txt     : This file
+ tiff6.pdf      : TIFF specification revision 6.0 
+
+CD-ROM 2:
+  - IMAGE2      : A directory containing 2nd CD-ROM test charts
+ imgspec2.rtf   : Image specification for CD-ROM2 in rtf format
+ imgspec2.txt   : Image specification for CD-ROM2 in txt format
+ readme.txt     : This file

--- a/testcases/bike/source
+++ b/testcases/bike/source
@@ -1,0 +1,3 @@
+Source: ITU-T T.24 (06/1998) - Standardized digitized image set
+Link: https://www.itu.int/rec/T-REC-T.24/
+License: see itu-t.24_ReadMe.txt

--- a/testcases/cafe/itu-t.24_ReadMe.txt
+++ b/testcases/cafe/itu-t.24_ReadMe.txt
@@ -1,0 +1,105 @@
+--------------------------------------------------------------
+	    README FILE FOR THE T.24 DIGITIZED IMAGE SET
+--------------------------------------------------------------
+
+TITLE
+-----
+
+ ITU-T T.24 (06/1998) - Standardized digitized image set
+ (CD-04 edition)
+
+Test images have played an important role throughout the development of Group 3
+and Group 4 facsimile. This digitized test chart set has been prepared with the
+goal of providing a standard set of images to facsimile experimenters. The set
+includes images that have been used over the years plus new images that are
+applicable for gray scale and color. The standard set of images will provide a
+consistent baseline for further work; for example, results of compression
+algorithm experiments and image quality tests can be compared by a broad range
+of users, knowing that the input image data is identical
+
+This digitized test chart set is an integral part of ITU-T Rec. T.24 and is
+published with it. The two CD-ROMs include a set of digitized images with
+different resolutions. A detailed description is given in T.24 for each test
+chart.
+
+COPYRIGHT AND INTELLECTUAL PROPERTY
+-----------------------------------
+
+In order to preserve and protect its rights, the International Telecommunication
+Union (ITU) fully retains all titles and rights in this software and does not
+sell any rights related thereto; it grants, however, the right to use the
+software by means of a licence not implying in any way any sale, renting or
+otherwise gain financial profit from making available the original software or
+any copy thereof.
+
+By the present licence, ITU grants users of the software a non-exclusive right
+to freely reproduce the information contained therein, so that it may be used
+for intended purposes only. Use of the software constitutes the agreement by
+users of the terms and conditions of the present notice.
+
+The present notice must be included in any copy of the software or the
+information contained therein.
+
+ITU CONTACTS
+------------
+
+For distribution of update software, please contact:
+Sales Department
+ITU
+Place des Nations
+CH-1211 Geneve 20
+SUISSE
+email: sales@itu.int
+
+For reporting problems, please contact TSB helpdesk service at:
+TSB Helpdesk service
+ITU
+Place des Nations
+CH-1211 Geneve 20
+SUISSE
+fax: +41 22 730 5853
+email: tsbedh@itu.int
+
+USAGE INSTRUCTIONS:
+-------------------
+
+The images can be viewed with any available viewer complying with the TIFF
+specification.
+
+Among others, there are the following shareware: VuePrint from Hamrick Software
+at http://www.hamrick.com and Paint Shop Pro at http://www.jasc.com.
+
+Located in the root directory of the first CD-ROM, you'll find the TIFF
+Specification Revision 6.0 in pdf format:
+
+   Tiff6.pdf           TIFF Specification Revision 6.0
+
+The following copyright statement is included in the TIFF Specification Revision 6.0:
+
+(c) 1986-1988, 1992 Aldus Corporation. Permission to copy without fee all
+or part of this material is granted provided that the copies are not made or
+distributed for direct commercial advantage and the Aldus copyright notice appears.
+If the majority of the document is copied or redistributed, it must be distributed
+verbatim, without repagination or reformatting. To copy otherwise requires specific
+permission from the Aldus Corporation.
+
+CD-ROM CONTENTS:
+----------------
+
+The first CD-ROM contains the charts which were already included in 1994 version.
+The second CD-ROM contains the supplementary test charts introduced in 1998 edition.
+
+The files are organized as follows:
+
+CD-ROM 1:
+  - IMAGE1      : A directory containing 1st CD-ROM test charts
+ imgspec1.rtf   : Image specification for CD-ROM1 in rtf format
+ imgspec1.txt   : Image specification for CD-ROM1 in txt format
+ readme.txt     : This file
+ tiff6.pdf      : TIFF specification revision 6.0 
+
+CD-ROM 2:
+  - IMAGE2      : A directory containing 2nd CD-ROM test charts
+ imgspec2.rtf   : Image specification for CD-ROM2 in rtf format
+ imgspec2.txt   : Image specification for CD-ROM2 in txt format
+ readme.txt     : This file

--- a/testcases/cafe/source
+++ b/testcases/cafe/source
@@ -1,0 +1,3 @@
+Source: ITU-T T.24 (06/1998) - Standardized digitized image set
+Link: https://www.itu.int/rec/T-REC-T.24/
+License: see itu-t.24_ReadMe.txt

--- a/testcases/progressive/source
+++ b/testcases/progressive/source
@@ -1,0 +1,14 @@
+This image is Copyright (c) Microsoft and was made available initially in the JPEG XR (ISO/IEC 29199-2) standardization activity.
+
+Microsoft Reference Photo Library Content
+All Images Copyright © 2003-2007 Microsoft Corporation
+
+Individuals and organizations using photos or portions of photos from this archive (“Content”)
+agree that all intellectual property rights therein remain the property of Microsoft Corporation.
+Microsoft grants you the right to use all or part of this content for any purpose.
+You agree to display a copyright notice sufficient to protect Microsoft’s copyright in the Content.
+The Content is provided to you “AS IS” without warranty of any kind and Microsoft disclaims all warranties,
+whether express, implied or statutory including but not limited to, the implied warranties of merchantability
+and fitness for a particular purpose, and warranties of title and noninfringement.
+
+For additional information, contact Bill Crow – billcrow@microsoft.com


### PR DESCRIPTION
This clarifies the licensing of the software and test data in this repository.

The software is licensed with the same license as the libjxl project: BSD 3-clause.

For the test bitstreams, I had to hunt down some information since some of the original images are quite old.

- The oldest test images (`bike` and `cafe`) are from ITU T.24; I added the readme from the CD-ROM they were originally distributed on. Bottom line is they can be freely distributed and used for testing purposes.
- One image (`progressive`, which originates from test image `p06`) has a custom Microsoft license that seems to be similar to CC BY.
- Two animations (`animation_icos4D` and `animation_newtons_cradle`) and one still image (`upsampling`) come from Wikimedia and have a CC0 or CC BY-SA license. Links were added.
- One image (`grayscale_public_university`) originates from the `ARRI_PublicUniversity_2880x1620p_24_8b_bt709_444_0000.ppm` test image and has a CC BY license.
- All other images are either based on an image from the jyrki31 set (which was created by @jyrkialakuijala ) or manually created by me or by @sboukortt. I am indicating those to be CC0 — @jyrkialakuijala and @sboukortt, please let me know if this is OK for you.

Next time we do this, remind me to only use CC0 images so we can keep the license info simple :)
