### PR TITLE
don't test bitexact decoded ICC profile if there is no ICC profile in bitstream

### DIFF
--- a/testcases/alpha_nonpremultiplied/test.json
+++ b/testcases/alpha_nonpremultiplied/test.json
@@ -21,9 +21,7 @@
     0,
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "cad070b944d8aff6b7865c211e44bc469b08addf5b4a19d11fdc4ef2f7494d1b"
   }

--- a/testcases/alpha_triangles/test.json
+++ b/testcases/alpha_triangles/test.json
@@ -21,9 +21,7 @@
     0,
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "1d8471e3b7f0768f408b5e5bf5fee0de49ad6886d846712b1aaa702379722e2b"
   }

--- a/testcases/animation_icos4d/test.json
+++ b/testcases/animation_icos4d/test.json
@@ -304,9 +304,7 @@
     0,
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "77a060cfa0d4df183255424e13e4f41a90b3edcea1248e3f22a3b7fcafe89e49"
   }

--- a/testcases/animation_icos4d_5/test.json
+++ b/testcases/animation_icos4d_5/test.json
@@ -304,9 +304,7 @@
     0,
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "ddf2d3c90f64e55a4701c86fe603846d1d515e147e83e1f9cb6ea925d6266cf9"
   }

--- a/testcases/animation_spline/test.json
+++ b/testcases/animation_spline/test.json
@@ -372,9 +372,7 @@
   "exp_bits_per_sample": [
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "a571c5cbba58affeeb43c44c13f81e2b1962727eb9d4e017e4f25d95c7388f10"
   }

--- a/testcases/animation_spline_5/test.json
+++ b/testcases/animation_spline_5/test.json
@@ -372,9 +372,7 @@
   "exp_bits_per_sample": [
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "a571c5cbba58affeeb43c44c13f81e2b1962727eb9d4e017e4f25d95c7388f10"
   }

--- a/testcases/bicycles/test.json
+++ b/testcases/bicycles/test.json
@@ -17,9 +17,7 @@
   "exp_bits_per_sample": [
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "6f71d8ca122872e7d850b672e7fb46b818c2dfddacd00b3934fe70aa8e0b327e"
   }

--- a/testcases/blendmodes/test.json
+++ b/testcases/blendmodes/test.json
@@ -21,9 +21,7 @@
     0,
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "6ef265631818f313a70cb23788d1185408ce07243db8d5940553e7ea7467b786"
   }

--- a/testcases/blendmodes_5/test.json
+++ b/testcases/blendmodes_5/test.json
@@ -21,9 +21,7 @@
     0,
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "6ef265631818f313a70cb23788d1185408ce07243db8d5940553e7ea7467b786"
   }

--- a/testcases/delta_palette/test.json
+++ b/testcases/delta_palette/test.json
@@ -17,9 +17,7 @@
   "exp_bits_per_sample": [
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "952b9e16aa0ae23df38c6b358cb4835b5f9479838f6855b96845ea54b0528c1f"
   }

--- a/testcases/noise/test.json
+++ b/testcases/noise/test.json
@@ -17,9 +17,7 @@
   "exp_bits_per_sample": [
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "b7bb25b911ab5f4b9a6a6da9c220c9ea738de685f9df25eb860e6bbe1302237d"
   }

--- a/testcases/noise_5/test.json
+++ b/testcases/noise_5/test.json
@@ -17,9 +17,7 @@
   "exp_bits_per_sample": [
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "b7bb25b911ab5f4b9a6a6da9c220c9ea738de685f9df25eb860e6bbe1302237d"
   }

--- a/testcases/opsin_inverse/test.json
+++ b/testcases/opsin_inverse/test.json
@@ -17,9 +17,7 @@
   "exp_bits_per_sample": [
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "a3142a144c112160b8e5a12eb17723fa5fe0cfeb00577e4fb59a5f6cea126a9b"
   }

--- a/testcases/opsin_inverse_5/test.json
+++ b/testcases/opsin_inverse_5/test.json
@@ -17,9 +17,7 @@
   "exp_bits_per_sample": [
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "a3142a144c112160b8e5a12eb17723fa5fe0cfeb00577e4fb59a5f6cea126a9b"
   }

--- a/testcases/sunset_logo/test.json
+++ b/testcases/sunset_logo/test.json
@@ -21,9 +21,7 @@
     0,
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "bf1c1d5626ced3746df867cf3e3a25f3d17512c2e837b5e3a04743660e42ad81"
   }

--- a/testcases/upsampling/test.json
+++ b/testcases/upsampling/test.json
@@ -21,9 +21,7 @@
     0,
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "9b83952c4bba9dc93fd5c5c49e27eab29301e848bf70dceccfec96b48d3ab975"
   }

--- a/testcases/upsampling_5/test.json
+++ b/testcases/upsampling_5/test.json
@@ -21,9 +21,7 @@
     0,
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "3c5362aa07f071b76c3570490b9229ede547db04ccc3f3ed6cf03f53b08708cf"
   }


### PR DESCRIPTION
We are testing that the synthesized ICC profile is an exact match, which is not needed and does not make sense: if decoders want to synthesize an ICC profile with a different name or copyright string, that's fine (it needs to be semantically equivalent but that's implicitly checked by using it to convert pixel values to the reference color space).

This test only makes sense in case the bitstream stores a compressed ICC profile: in that case the decoded ICC profile should match bit-exactly to the original profile. But in these cases the bitstream uses the enum syntax so there is no real `original.icc`.
