### PR TITLE
Forgot level10

### DIFF
--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -43,8 +43,10 @@ def CompareNPY(ref, ref_icc, dec, dec_icc, frame_idx, rmse_limit, peak_error, la
         return Failure(f'Expected shape {ref.shape} but found {dec.shape}')
     num_channels = ref_frame.shape[2]
 
-    if ref_icc != dec_icc:
+    if ref_icc != dec_icc && peak_error > 0:
         # Transform colors before comparison.
+        # Skip this if we expect fully lossless, since it introduces tiny errors
+        # (even in the case where ref_icc and dec_icc are equivalent so it's a no-op)
         if num_channels >= 3:
             dec_clr = dec_frame[:, :, 0:3]
             dec_frame[:, :, 0:3] = lcms2.convert_pixels(dec_icc, ref_icc, dec_clr)

--- a/testcases/alpha_premultiplied/test.json
+++ b/testcases/alpha_premultiplied/test.json
@@ -21,9 +21,7 @@
     0,
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "073c1d942ba408f94f6c0aed2fef3d442574899901c616afa060dbd8044bbdb9"
   }

--- a/testcases/animation_newtons_cradle/test.json
+++ b/testcases/animation_newtons_cradle/test.json
@@ -232,9 +232,7 @@
     0,
     0
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "80a1d9ea2892c89ab10a05fcbd1d752069557768fac3159ecd91c33be0d74a19",
     "reference_image.npy": "4309286cd22fa4008db3dcceee6a72a806c9291bd7e035cf555f3b470d0693d8"
   }

--- a/testcases/lossless_pfm/test.json
+++ b/testcases/lossless_pfm/test.json
@@ -17,9 +17,7 @@
   "exp_bits_per_sample": [
     8
   ],
-  "original_icc": "original.icc",
   "sha256sums": {
-    "original.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference.icc": "d7f9e32ac2a06a7e3865a828e865dafb7cf1947584d3c06ec97a660c59786b51",
     "reference_image.npy": "1eac3ced5c60ef8a3a602f54c6a9d28162dfee51cd85b8dd7e52f6e3212bbb52"
   }


### PR DESCRIPTION
Sorry about the multiple pull requests, this time I forgot to update the level 10 test.

Needed to avoid doing an lcms2 conversion in the case of `lossless_pfm`, since apparently doing a conversion from sRGB to sRGB (profiles differing only in their description string) is not a no-op but introduces some tiny errors:

```
RMSE: [1.6235774e-08, 5.960465e-11, 2.5352236e-08], actual peak: 1.1920928955078125e-07
RMSE too large: 2.535223586619395e-08 > 0.0
```
